### PR TITLE
Fixes on bUtility.Dapper and bUtility.WebApi

### DIFF
--- a/bUtility.Dapper/DMLExtensions.cs
+++ b/bUtility.Dapper/DMLExtensions.cs
@@ -59,10 +59,10 @@ namespace bUtility.Dapper
         public static string GetUpdateClause(this object obj, bool includeNulls = false, DMLOptions options = null)
         {
             var part1 = obj?.GetMemberNames<PropertyInfo>((PropertyInfo pInfo) => pInfo.GetValue(obj) != null)?
-                .Select(c => $"{c.SetIdentifierDelimeters(options)} = {c.SetUpdateParameterDelimeter(options)}").Concatenate((c, n) => $"{c} and {n}");
+                .Select(c => $"{c.SetIdentifierDelimeters(options)} = {c.SetUpdateParameterDelimeter(options)}").Concatenate((c, n) => $"{c}, {n}");
             if (!includeNulls) return part1;
-            var part2 = obj.GetMemberNames<PropertyInfo>((PropertyInfo pInfo) => pInfo.GetValue(obj) == null)?.Select(c => $"{c.SetIdentifierDelimeters(options)} is null")?.Concatenate((c, n) => $"{c} and {n}");
-            if (part1.Clear() != null && part2.Clear() != null) return $"{part1} and {part2}";
+            var part2 = obj.GetMemberNames<PropertyInfo>((PropertyInfo pInfo) => pInfo.GetValue(obj) == null)?.Select(c => $"{c.SetIdentifierDelimeters(options)} is null")?.Concatenate((c, n) => $"{c}, {n}");
+            if (part1.Clear() != null && part2.Clear() != null) return $"{part1}, {part2}";
             return part1 ?? part2;
         }
 

--- a/bUtility.Dapper/Properties/AssemblyInfo.cs
+++ b/bUtility.Dapper/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.0.11")]
-[assembly: AssemblyFileVersion("0.0.0.11")]
+[assembly: AssemblyVersion("0.0.0.12")]
+[assembly: AssemblyFileVersion("0.0.0.12")]

--- a/bUtility.WebApi/ReflectionExtensions.cs
+++ b/bUtility.WebApi/ReflectionExtensions.cs
@@ -45,7 +45,6 @@ namespace bUtility.WebApi
             else {
                 obj.GetType().GetProperties().ToList().ForEach(p =>
                 {
-                    Console.WriteLine(p.Name);
                     if (p.PropertyType.IsClass
                     && p.PropertyType != typeof(string)
                     && !p.PropertyType.IsArray)


### PR DESCRIPTION
bUtility.Dapper:
 - Update clause emitted wrong sql code when updating multiple columns

bUtility.WebApi:
 - ReflectionExtensions contained a redundant Console.WriteLine 